### PR TITLE
docs: Update README - Replace LlamaIndex with BeautifulSoup4

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Once running, you can:
 - **ChromaDB**: Vector database for knowledge storage
 - **Rich**: Terminal UI framework
 - **LangGraph**: Agent orchestration
-- **LlamaIndex**: Document processing and retrieval
+- **BeautifulSoup4**: Web content extraction
 
 ## License
 


### PR DESCRIPTION
## Summary

- Replaces incorrect LlamaIndex mention with BeautifulSoup4 in the README Architecture section
- The codebase uses BeautifulSoup4 for web content extraction (in `document_ingestion.py`), not LlamaIndex

## Changes

- `README.md`: Changed "LlamaIndex: Document processing and retrieval" to "BeautifulSoup4: Web content extraction"

## Test plan

- [x] Verify README accurately reflects actual dependencies used in the code
- [x] Confirm BeautifulSoup4 is listed in requirements.txt (line 26)
- [x] Confirm LlamaIndex is not imported or used in any Python files

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)