### PR TITLE
feat: Add Knowledge Export/Import

### DIFF
--- a/src/knowledge_base.py
+++ b/src/knowledge_base.py
@@ -2,6 +2,7 @@ import chromadb
 from chromadb.config import Settings as ChromaSettings
 from typing import List, Dict, Any, Optional
 from pathlib import Path
+from datetime import datetime
 import logging
 import json
 from src.config import settings
@@ -175,14 +176,172 @@ class KnowledgeBase:
     def get_stats(self) -> Dict[str, Any]:
         """Get statistics about the knowledge base."""
         collection_data = self.collection.get()
-        
+
         stats = {
             "total_documents": len(collection_data['ids']),
             "types": {}
         }
-        
+
         for metadata in collection_data['metadatas']:
             doc_type = metadata.get('type', 'unknown')
             stats['types'][doc_type] = stats['types'].get(doc_type, 0) + 1
-            
+
         return stats
+
+    def export_knowledge(
+        self,
+        filter_type: Optional[str] = None,
+        filter_source: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Export knowledge base to a JSON-serializable dictionary.
+
+        Args:
+            filter_type: Optional filter by document type (e.g., "value", "framework")
+            filter_source: Optional filter by source (e.g., "knowledge_files", "web")
+
+        Returns:
+            Dictionary containing export metadata and documents
+        """
+        try:
+            # Get all documents including embeddings
+            collection_data = self.collection.get(include=["documents", "metadatas", "embeddings"])
+
+            exported_documents = []
+
+            for i, (doc_id, content, metadata, embedding) in enumerate(zip(
+                collection_data['ids'],
+                collection_data['documents'],
+                collection_data['metadatas'],
+                collection_data.get('embeddings', [None] * len(collection_data['ids']))
+            )):
+                # Apply filters
+                if filter_type and metadata.get('type') != filter_type:
+                    continue
+                if filter_source and metadata.get('source') != filter_source:
+                    continue
+
+                doc_export = {
+                    "id": doc_id,
+                    "content": content,
+                    "metadata": metadata,
+                }
+
+                # Include embeddings if available
+                if embedding is not None:
+                    doc_export["embedding"] = embedding
+
+                exported_documents.append(doc_export)
+
+            export_data = {
+                "export_version": "1.0",
+                "export_timestamp": datetime.now().isoformat(),
+                "collection_name": settings.chroma_collection_name,
+                "total_documents": len(exported_documents),
+                "filters": {
+                    "type": filter_type,
+                    "source": filter_source
+                },
+                "documents": exported_documents
+            }
+
+            logger.info(f"Exported {len(exported_documents)} documents")
+            return export_data
+
+        except Exception as e:
+            logger.error(f"Error exporting knowledge base: {e}")
+            raise
+
+    def import_knowledge(
+        self,
+        import_data: Dict[str, Any],
+        duplicate_handling: str = "skip"
+    ) -> Dict[str, Any]:
+        """
+        Import knowledge from a previously exported dictionary.
+
+        Args:
+            import_data: Dictionary from export_knowledge
+            duplicate_handling: How to handle duplicates - "skip", "update", or "fail"
+
+        Returns:
+            Dictionary with import statistics
+        """
+        try:
+            # Validate import data structure
+            if "documents" not in import_data:
+                raise ValueError("Invalid import data: missing 'documents' key")
+
+            if "export_version" not in import_data:
+                logger.warning("Import data missing version info, proceeding with caution")
+
+            documents = import_data["documents"]
+
+            # Get existing document IDs
+            existing_ids = set(self.collection.get()['ids'])
+
+            stats = {
+                "total_in_file": len(documents),
+                "added": 0,
+                "updated": 0,
+                "skipped": 0,
+                "errors": 0,
+                "error_messages": []
+            }
+
+            for doc in documents:
+                try:
+                    doc_id = doc.get("id")
+                    content = doc.get("content")
+                    metadata = doc.get("metadata", {})
+                    embedding = doc.get("embedding")
+
+                    if not doc_id or not content:
+                        stats["errors"] += 1
+                        stats["error_messages"].append(f"Document missing id or content")
+                        continue
+
+                    # Check for duplicates
+                    if doc_id in existing_ids:
+                        if duplicate_handling == "skip":
+                            stats["skipped"] += 1
+                            continue
+                        elif duplicate_handling == "fail":
+                            raise ValueError(f"Duplicate document ID: {doc_id}")
+                        elif duplicate_handling == "update":
+                            # Delete existing and re-add
+                            self.collection.delete(ids=[doc_id])
+                            existing_ids.remove(doc_id)
+
+                    # Generate embedding if not provided
+                    if embedding is None:
+                        embedding = self.ollama_client.get_embeddings(content)
+
+                    # Add document
+                    self.collection.add(
+                        documents=[content],
+                        embeddings=[embedding],
+                        metadatas=[metadata],
+                        ids=[doc_id]
+                    )
+
+                    existing_ids.add(doc_id)
+
+                    if duplicate_handling == "update" and doc_id in existing_ids:
+                        stats["updated"] += 1
+                    else:
+                        stats["added"] += 1
+
+                except Exception as e:
+                    stats["errors"] += 1
+                    stats["error_messages"].append(f"Error importing {doc.get('id', 'unknown')}: {str(e)}")
+                    logger.error(f"Error importing document: {e}")
+
+            logger.info(f"Import complete: {stats['added']} added, {stats['updated']} updated, "
+                       f"{stats['skipped']} skipped, {stats['errors']} errors")
+
+            return stats
+
+        except Exception as e:
+            logger.error(f"Error importing knowledge base: {e}")
+            raise

--- a/src/main.py
+++ b/src/main.py
@@ -220,6 +220,16 @@ class GlennBot:
         elif command == "/feedback-insights":
             self._show_feedback_insights()
 
+        # Knowledge export/import commands
+        elif command == "/export-knowledge" or command.startswith("/export-knowledge "):
+            parts = command.split(" ", 1)
+            filename = parts[1] if len(parts) > 1 else None
+            self._export_knowledge(filename)
+
+        elif command.startswith("/import-knowledge "):
+            filename = command.split(" ", 1)[1]
+            self._import_knowledge(filename)
+
         else:
             self.ui.display_error(f"Unknown command: {command}")
             
@@ -1125,6 +1135,126 @@ class GlennBot:
         except Exception as e:
             logger.error(f"Error showing feedback insights: {e}")
             self.ui.display_error(f"Failed to show feedback insights: {e}")
+
+    def _export_knowledge(self, filename: Optional[str] = None):
+        """Export the knowledge base to a JSON file."""
+        try:
+            # Generate default filename if not provided
+            if not filename:
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                filename = f"knowledge_backup_{timestamp}.json"
+
+            # Ask for optional filters
+            self.ui.console.print("[yellow]Export Options:[/yellow]")
+            self.ui.console.print("1. Export all documents")
+            self.ui.console.print("2. Export by type (value, framework, preference, memory, etc.)")
+            self.ui.console.print("3. Export by source (knowledge_files, web, etc.)")
+
+            try:
+                choice = input("Select option (1-3, default 1): ").strip() or "1"
+
+                filter_type = None
+                filter_source = None
+
+                if choice == "2":
+                    # Show available types
+                    stats = self.knowledge_base.get_stats()
+                    self.ui.console.print(f"[dim]Available types: {', '.join(stats['types'].keys())}[/dim]")
+                    filter_type = input("Enter type to export: ").strip()
+                elif choice == "3":
+                    filter_source = input("Enter source to export: ").strip()
+
+                with self.ui.show_thinking_indicator():
+                    export_data = self.knowledge_base.export_knowledge(
+                        filter_type=filter_type,
+                        filter_source=filter_source
+                    )
+
+                # Write to file
+                output_path = Path(filename)
+                with open(output_path, 'w') as f:
+                    json.dump(export_data, f, indent=2)
+
+                self.ui.console.print(f"[green]✓ Exported {export_data['total_documents']} documents to {filename}[/green]")
+                self.ui.console.print(f"[dim]Export timestamp: {export_data['export_timestamp']}[/dim]")
+
+                if filter_type or filter_source:
+                    self.ui.console.print(f"[dim]Filters applied - Type: {filter_type}, Source: {filter_source}[/dim]")
+
+            except KeyboardInterrupt:
+                self.ui.console.print("\n[dim]Export cancelled[/dim]")
+
+        except Exception as e:
+            logger.error(f"Error exporting knowledge: {e}")
+            self.ui.display_error(f"Failed to export knowledge: {e}")
+
+    def _import_knowledge(self, filename: str):
+        """Import knowledge from a JSON backup file."""
+        try:
+            input_path = Path(filename)
+
+            if not input_path.exists():
+                self.ui.display_error(f"File not found: {filename}")
+                return
+
+            # Load the file
+            with open(input_path, 'r') as f:
+                import_data = json.load(f)
+
+            # Show import info
+            self.ui.console.print(f"[yellow]Import File: {filename}[/yellow]")
+            self.ui.console.print(f"[dim]Export version: {import_data.get('export_version', 'unknown')}[/dim]")
+            self.ui.console.print(f"[dim]Export timestamp: {import_data.get('export_timestamp', 'unknown')}[/dim]")
+            self.ui.console.print(f"[dim]Documents in file: {import_data.get('total_documents', len(import_data.get('documents', [])))}[/dim]")
+
+            # Ask for duplicate handling
+            self.ui.console.print("\n[yellow]Duplicate Handling:[/yellow]")
+            self.ui.console.print("1. Skip - Don't import documents with existing IDs (default)")
+            self.ui.console.print("2. Update - Replace existing documents with import data")
+            self.ui.console.print("3. Fail - Stop import if any duplicates found")
+
+            try:
+                choice = input("Select option (1-3, default 1): ").strip() or "1"
+
+                duplicate_map = {"1": "skip", "2": "update", "3": "fail"}
+                duplicate_handling = duplicate_map.get(choice, "skip")
+
+                # Confirm import
+                confirm = input(f"Proceed with import ({duplicate_handling} duplicates)? [y/N]: ").strip().lower()
+                if confirm != 'y':
+                    self.ui.console.print("[dim]Import cancelled[/dim]")
+                    return
+
+                with self.ui.show_thinking_indicator():
+                    stats = self.knowledge_base.import_knowledge(
+                        import_data,
+                        duplicate_handling=duplicate_handling
+                    )
+
+                # Show results
+                self.ui.console.print(f"[green]✓ Import complete![/green]")
+                self.ui.console.print(f"  Documents in file: {stats['total_in_file']}")
+                self.ui.console.print(f"  Added: {stats['added']}")
+                self.ui.console.print(f"  Updated: {stats['updated']}")
+                self.ui.console.print(f"  Skipped: {stats['skipped']}")
+
+                if stats['errors'] > 0:
+                    self.ui.console.print(f"[yellow]  Errors: {stats['errors']}[/yellow]")
+                    for error_msg in stats['error_messages'][:5]:  # Show first 5 errors
+                        self.ui.console.print(f"[dim]    - {error_msg}[/dim]")
+
+                # Show new stats
+                new_stats = self.knowledge_base.get_stats()
+                self.ui.console.print(f"\n[dim]Knowledge base now has {new_stats['total_documents']} total documents[/dim]")
+
+            except KeyboardInterrupt:
+                self.ui.console.print("\n[dim]Import cancelled[/dim]")
+
+        except json.JSONDecodeError as e:
+            self.ui.display_error(f"Invalid JSON file: {e}")
+        except Exception as e:
+            logger.error(f"Error importing knowledge: {e}")
+            self.ui.display_error(f"Failed to import knowledge: {e}")
 
     def run(self):
         """Main application loop."""

--- a/src/terminal_ui.py
+++ b/src/terminal_ui.py
@@ -154,6 +154,8 @@ Let's collaborate!
 - `/add-url <url> [context]` - Add content from a webpage to knowledge base
 - `/add-text <name> [context]` - Add manually entered text to knowledge base
 - `/clean-knowledge` - Remove duplicate knowledge base entries
+- `/export-knowledge [filename]` - Export knowledge base to JSON backup
+- `/import-knowledge <filename>` - Import knowledge from JSON backup
 
 ### Quotes & Inspiration
 - `/add-quote "<quote>" "<author>" [context]` - Add an inspirational quote

--- a/tests/test_knowledge_base.py
+++ b/tests/test_knowledge_base.py
@@ -388,3 +388,305 @@ class TestKnowledgeBase:
             kb.search("test query")
 
         assert "Search failed" in str(exc_info.value)
+
+    @patch('src.knowledge_base.OllamaClient')
+    @patch('src.knowledge_base.chromadb')
+    @patch('src.knowledge_base.settings')
+    def test_export_knowledge(self, mock_settings, mock_chromadb, mock_ollama_class, temp_dir):
+        """Test exporting knowledge base to dictionary."""
+        mock_settings.chroma_persist_directory = temp_dir / "chroma"
+        mock_settings.chroma_collection_name = "test_collection"
+
+        # Mock chromadb
+        mock_collection = MagicMock()
+        mock_collection.get.return_value = {
+            "ids": ["doc_1", "doc_2", "doc_3"],
+            "documents": ["Content 1", "Content 2", "Content 3"],
+            "metadatas": [
+                {"type": "value", "source": "knowledge_files"},
+                {"type": "framework", "source": "knowledge_files"},
+                {"type": "value", "source": "web"}
+            ],
+            "embeddings": [[0.1] * 768, [0.2] * 768, [0.3] * 768]
+        }
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.return_value = mock_collection
+        mock_chromadb.PersistentClient.return_value = mock_client
+
+        # Mock ollama
+        mock_ollama_instance = MagicMock()
+        mock_ollama_class.return_value = mock_ollama_instance
+
+        from src.knowledge_base import KnowledgeBase
+
+        kb = KnowledgeBase()
+        export_data = kb.export_knowledge()
+
+        assert export_data["export_version"] == "1.0"
+        assert "export_timestamp" in export_data
+        assert export_data["total_documents"] == 3
+        assert len(export_data["documents"]) == 3
+        assert export_data["documents"][0]["id"] == "doc_1"
+        assert export_data["documents"][0]["content"] == "Content 1"
+
+    @patch('src.knowledge_base.OllamaClient')
+    @patch('src.knowledge_base.chromadb')
+    @patch('src.knowledge_base.settings')
+    def test_export_knowledge_with_type_filter(self, mock_settings, mock_chromadb, mock_ollama_class, temp_dir):
+        """Test exporting knowledge with type filter."""
+        mock_settings.chroma_persist_directory = temp_dir / "chroma"
+        mock_settings.chroma_collection_name = "test_collection"
+
+        # Mock chromadb
+        mock_collection = MagicMock()
+        mock_collection.get.return_value = {
+            "ids": ["doc_1", "doc_2", "doc_3"],
+            "documents": ["Content 1", "Content 2", "Content 3"],
+            "metadatas": [
+                {"type": "value", "source": "knowledge_files"},
+                {"type": "framework", "source": "knowledge_files"},
+                {"type": "value", "source": "web"}
+            ],
+            "embeddings": [[0.1] * 768, [0.2] * 768, [0.3] * 768]
+        }
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.return_value = mock_collection
+        mock_chromadb.PersistentClient.return_value = mock_client
+
+        # Mock ollama
+        mock_ollama_instance = MagicMock()
+        mock_ollama_class.return_value = mock_ollama_instance
+
+        from src.knowledge_base import KnowledgeBase
+
+        kb = KnowledgeBase()
+        export_data = kb.export_knowledge(filter_type="value")
+
+        # Should only export documents with type "value"
+        assert export_data["total_documents"] == 2
+        assert len(export_data["documents"]) == 2
+        assert all(doc["metadata"]["type"] == "value" for doc in export_data["documents"])
+
+    @patch('src.knowledge_base.OllamaClient')
+    @patch('src.knowledge_base.chromadb')
+    @patch('src.knowledge_base.settings')
+    def test_export_knowledge_with_source_filter(self, mock_settings, mock_chromadb, mock_ollama_class, temp_dir):
+        """Test exporting knowledge with source filter."""
+        mock_settings.chroma_persist_directory = temp_dir / "chroma"
+        mock_settings.chroma_collection_name = "test_collection"
+
+        # Mock chromadb
+        mock_collection = MagicMock()
+        mock_collection.get.return_value = {
+            "ids": ["doc_1", "doc_2", "doc_3"],
+            "documents": ["Content 1", "Content 2", "Content 3"],
+            "metadatas": [
+                {"type": "value", "source": "knowledge_files"},
+                {"type": "framework", "source": "knowledge_files"},
+                {"type": "value", "source": "web"}
+            ],
+            "embeddings": [[0.1] * 768, [0.2] * 768, [0.3] * 768]
+        }
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.return_value = mock_collection
+        mock_chromadb.PersistentClient.return_value = mock_client
+
+        # Mock ollama
+        mock_ollama_instance = MagicMock()
+        mock_ollama_class.return_value = mock_ollama_instance
+
+        from src.knowledge_base import KnowledgeBase
+
+        kb = KnowledgeBase()
+        export_data = kb.export_knowledge(filter_source="web")
+
+        # Should only export documents with source "web"
+        assert export_data["total_documents"] == 1
+        assert export_data["documents"][0]["metadata"]["source"] == "web"
+
+    @patch('src.knowledge_base.OllamaClient')
+    @patch('src.knowledge_base.chromadb')
+    @patch('src.knowledge_base.settings')
+    def test_import_knowledge_skip_duplicates(self, mock_settings, mock_chromadb, mock_ollama_class, temp_dir):
+        """Test importing knowledge with skip duplicates strategy."""
+        mock_settings.chroma_persist_directory = temp_dir / "chroma"
+        mock_settings.chroma_collection_name = "test_collection"
+
+        # Mock chromadb
+        mock_collection = MagicMock()
+        # Existing docs have doc_1
+        mock_collection.get.return_value = {"ids": ["doc_1"]}
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.return_value = mock_collection
+        mock_chromadb.PersistentClient.return_value = mock_client
+
+        # Mock ollama
+        mock_ollama_instance = MagicMock()
+        mock_ollama_instance.get_embeddings.return_value = [0.1] * 768
+        mock_ollama_class.return_value = mock_ollama_instance
+
+        from src.knowledge_base import KnowledgeBase
+
+        kb = KnowledgeBase()
+
+        import_data = {
+            "export_version": "1.0",
+            "documents": [
+                {"id": "doc_1", "content": "Duplicate content", "metadata": {"type": "value"}},
+                {"id": "doc_2", "content": "New content", "metadata": {"type": "framework"}}
+            ]
+        }
+
+        stats = kb.import_knowledge(import_data, duplicate_handling="skip")
+
+        assert stats["total_in_file"] == 2
+        assert stats["skipped"] == 1  # doc_1 skipped
+        assert stats["added"] == 1   # doc_2 added
+        assert stats["errors"] == 0
+
+    @patch('src.knowledge_base.OllamaClient')
+    @patch('src.knowledge_base.chromadb')
+    @patch('src.knowledge_base.settings')
+    def test_import_knowledge_update_duplicates(self, mock_settings, mock_chromadb, mock_ollama_class, temp_dir):
+        """Test importing knowledge with update duplicates strategy."""
+        mock_settings.chroma_persist_directory = temp_dir / "chroma"
+        mock_settings.chroma_collection_name = "test_collection"
+
+        # Mock chromadb
+        mock_collection = MagicMock()
+        mock_collection.get.return_value = {"ids": ["doc_1"]}
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.return_value = mock_collection
+        mock_chromadb.PersistentClient.return_value = mock_client
+
+        # Mock ollama
+        mock_ollama_instance = MagicMock()
+        mock_ollama_instance.get_embeddings.return_value = [0.1] * 768
+        mock_ollama_class.return_value = mock_ollama_instance
+
+        from src.knowledge_base import KnowledgeBase
+
+        kb = KnowledgeBase()
+
+        import_data = {
+            "export_version": "1.0",
+            "documents": [
+                {"id": "doc_1", "content": "Updated content", "metadata": {"type": "value"}}
+            ]
+        }
+
+        stats = kb.import_knowledge(import_data, duplicate_handling="update")
+
+        # Should have deleted and re-added
+        mock_collection.delete.assert_called_with(ids=["doc_1"])
+        assert stats["added"] == 1
+
+    @patch('src.knowledge_base.OllamaClient')
+    @patch('src.knowledge_base.chromadb')
+    @patch('src.knowledge_base.settings')
+    def test_import_knowledge_fail_on_duplicates(self, mock_settings, mock_chromadb, mock_ollama_class, temp_dir):
+        """Test importing knowledge fails on duplicates when configured."""
+        mock_settings.chroma_persist_directory = temp_dir / "chroma"
+        mock_settings.chroma_collection_name = "test_collection"
+
+        # Mock chromadb
+        mock_collection = MagicMock()
+        mock_collection.get.return_value = {"ids": ["doc_1"]}
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.return_value = mock_collection
+        mock_chromadb.PersistentClient.return_value = mock_client
+
+        # Mock ollama
+        mock_ollama_instance = MagicMock()
+        mock_ollama_class.return_value = mock_ollama_instance
+
+        from src.knowledge_base import KnowledgeBase
+
+        kb = KnowledgeBase()
+
+        import_data = {
+            "export_version": "1.0",
+            "documents": [
+                {"id": "doc_1", "content": "Duplicate", "metadata": {"type": "value"}}
+            ]
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            kb.import_knowledge(import_data, duplicate_handling="fail")
+
+        assert "Duplicate document ID" in str(exc_info.value)
+
+    @patch('src.knowledge_base.OllamaClient')
+    @patch('src.knowledge_base.chromadb')
+    @patch('src.knowledge_base.settings')
+    def test_import_knowledge_invalid_data(self, mock_settings, mock_chromadb, mock_ollama_class, temp_dir):
+        """Test importing invalid data raises error."""
+        mock_settings.chroma_persist_directory = temp_dir / "chroma"
+        mock_settings.chroma_collection_name = "test_collection"
+
+        # Mock chromadb
+        mock_collection = MagicMock()
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.return_value = mock_collection
+        mock_chromadb.PersistentClient.return_value = mock_client
+
+        # Mock ollama
+        mock_ollama_instance = MagicMock()
+        mock_ollama_class.return_value = mock_ollama_instance
+
+        from src.knowledge_base import KnowledgeBase
+
+        kb = KnowledgeBase()
+
+        # Missing documents key
+        invalid_data = {"export_version": "1.0"}
+
+        with pytest.raises(ValueError) as exc_info:
+            kb.import_knowledge(invalid_data)
+
+        assert "missing 'documents' key" in str(exc_info.value)
+
+    @patch('src.knowledge_base.OllamaClient')
+    @patch('src.knowledge_base.chromadb')
+    @patch('src.knowledge_base.settings')
+    def test_import_knowledge_uses_provided_embeddings(self, mock_settings, mock_chromadb, mock_ollama_class, temp_dir):
+        """Test that import uses provided embeddings instead of generating new ones."""
+        mock_settings.chroma_persist_directory = temp_dir / "chroma"
+        mock_settings.chroma_collection_name = "test_collection"
+
+        # Mock chromadb
+        mock_collection = MagicMock()
+        mock_collection.get.return_value = {"ids": []}
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.return_value = mock_collection
+        mock_chromadb.PersistentClient.return_value = mock_client
+
+        # Mock ollama
+        mock_ollama_instance = MagicMock()
+        mock_ollama_class.return_value = mock_ollama_instance
+
+        from src.knowledge_base import KnowledgeBase
+
+        kb = KnowledgeBase()
+
+        provided_embedding = [0.5] * 768
+        import_data = {
+            "export_version": "1.0",
+            "documents": [
+                {
+                    "id": "doc_1",
+                    "content": "Content with embedding",
+                    "metadata": {"type": "value"},
+                    "embedding": provided_embedding
+                }
+            ]
+        }
+
+        kb.import_knowledge(import_data)
+
+        # Should not have called get_embeddings since embedding was provided
+        mock_ollama_instance.get_embeddings.assert_not_called()
+
+        # Should have used the provided embedding
+        call_kwargs = mock_collection.add.call_args
+        assert call_kwargs[1]["embeddings"] == [provided_embedding]


### PR DESCRIPTION
## Summary
- Implements knowledge base export/import functionality to enable backup, restore, and transfer of the knowledge base
- Adds `/export-knowledge` and `/import-knowledge` CLI commands
- Includes comprehensive unit tests for the new functionality

## Changes
- **src/knowledge_base.py**: Added `export_knowledge()` and `import_knowledge()` methods
  - Export includes all documents with IDs, content, metadata, and embeddings
  - Optional filters by type or source for partial exports
  - Import supports configurable duplicate handling (skip, update, fail)
  - Uses provided embeddings when available to avoid regeneration

- **src/main.py**: Added CLI command handlers
  - `/export-knowledge [filename]` - Interactive export with filter options
  - `/import-knowledge <filename>` - Import with duplicate handling options

- **src/terminal_ui.py**: Updated help documentation

- **tests/test_knowledge_base.py**: Added 8 new test cases covering:
  - Basic export functionality
  - Export with type/source filters
  - Import with skip/update/fail duplicate strategies
  - Invalid data handling
  - Embedding preservation during import

## Test plan
- [x] All Python syntax checks pass
- [x] Unit tests added for new functionality
- [ ] Manual testing of export command with various filter options
- [ ] Manual testing of import command with different duplicate strategies
- [ ] Verify exported JSON file format

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)