### PR TITLE
feat: Add context auto-switching based on conversation topic

### DIFF
--- a/src/agents.py
+++ b/src/agents.py
@@ -398,7 +398,7 @@ class AgentOrchestrator:
 Original Query: {query}
 
 Expert Responses:
-{chr(10).join([f"**{r['agent']}** (confidence: {r['confidence']:.2f}):\n{r['response']}\n" for r in responses])}
+{chr(10).join([f"**{r['agent']}** (confidence: {r['confidence']:.2f}):{chr(10)}{r['response']}{chr(10)}" for r in responses])}
 
 Apply your reasoning capabilities to:
 1. Identify the best insights from each perspective

--- a/src/context_detector.py
+++ b/src/context_detector.py
@@ -1,0 +1,280 @@
+"""Context detection and auto-switching for conversations."""
+
+from typing import Dict, Optional, Tuple
+from dataclasses import dataclass
+import json
+import re
+import logging
+from src.ollama_client import OllamaClient
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ContextSwitchResult:
+    """Result of context switch evaluation."""
+    should_switch: bool
+    recommended_context: Optional[str]
+    confidence: float
+    needs_confirmation: bool
+    scores: Dict[str, float]
+
+
+class ContextDetector:
+    """Detects conversation context and recommends context switches."""
+
+    # Default context types that can be auto-detected
+    CONTEXT_TYPES = {
+        "work": {
+            "description": "Professional work, career, business tasks, meetings, deadlines",
+            "keywords": ["work", "job", "project", "deadline", "meeting", "client", "task",
+                        "report", "email", "schedule", "team", "boss", "colleague", "career",
+                        "professional", "business", "company", "office", "presentation"]
+        },
+        "personal": {
+            "description": "Personal life, family, friends, health, daily activities",
+            "keywords": ["family", "friend", "health", "exercise", "home", "weekend",
+                        "vacation", "hobby", "personal", "relationship", "dinner", "movie",
+                        "birthday", "celebration", "shopping", "relax"]
+        },
+        "creative": {
+            "description": "Creative projects, art, writing, music, brainstorming ideas",
+            "keywords": ["creative", "write", "story", "art", "design", "music", "paint",
+                        "idea", "brainstorm", "imagine", "create", "inspiration", "poem",
+                        "novel", "compose", "sketch", "craft", "invent"]
+        },
+        "reflection": {
+            "description": "Self-reflection, personal growth, philosophy, deep thinking",
+            "keywords": ["reflect", "think", "feel", "growth", "mindset", "philosophy",
+                        "meaning", "purpose", "goal", "dream", "fear", "hope", "believe",
+                        "learn", "understand", "wisdom", "insight", "journal", "gratitude"]
+        }
+    }
+
+    def __init__(self, ollama_client: OllamaClient,
+                 auto_switch_threshold: float = 0.8,
+                 prompt_threshold: float = 0.6):
+        """Initialize the context detector.
+
+        Args:
+            ollama_client: OllamaClient for LLM-based classification
+            auto_switch_threshold: Confidence above which to auto-switch silently
+            prompt_threshold: Confidence above which to prompt user for confirmation
+        """
+        self.ollama_client = ollama_client
+        self.auto_switch_threshold = auto_switch_threshold
+        self.prompt_threshold = prompt_threshold
+
+    def classify_message(self, message: str,
+                        recent_context: str = None) -> Dict[str, float]:
+        """Classify a message and return confidence scores for each context.
+
+        Args:
+            message: The user message to classify
+            recent_context: Optional recent conversation context for better classification
+
+        Returns:
+            Dict mapping context IDs to confidence scores (0.0 to 1.0)
+        """
+        # First try quick keyword-based classification
+        keyword_scores = self._keyword_classify(message)
+
+        # If clear winner from keywords (high confidence), use that
+        max_keyword_score = max(keyword_scores.values()) if keyword_scores else 0
+        if max_keyword_score >= 0.7:
+            return keyword_scores
+
+        # Otherwise, use LLM for more nuanced classification
+        try:
+            llm_scores = self._llm_classify(message, recent_context)
+
+            # Blend keyword and LLM scores (favor LLM but incorporate keywords)
+            blended_scores = {}
+            for context_id in self.CONTEXT_TYPES:
+                keyword_score = keyword_scores.get(context_id, 0.0)
+                llm_score = llm_scores.get(context_id, 0.0)
+                # Weight LLM more heavily (70% LLM, 30% keywords)
+                blended_scores[context_id] = (0.7 * llm_score) + (0.3 * keyword_score)
+
+            return blended_scores
+
+        except Exception as e:
+            logger.warning(f"LLM classification failed, using keywords only: {e}")
+            return keyword_scores
+
+    def _keyword_classify(self, message: str) -> Dict[str, float]:
+        """Quick keyword-based classification.
+
+        Args:
+            message: The message to classify
+
+        Returns:
+            Dict mapping context IDs to confidence scores
+        """
+        message_lower = message.lower()
+        scores = {}
+
+        for context_id, config in self.CONTEXT_TYPES.items():
+            keyword_matches = sum(
+                1 for keyword in config["keywords"]
+                if keyword in message_lower
+            )
+            # Normalize by number of keywords (max score ~1.0 for 5+ matches)
+            score = min(keyword_matches / 5.0, 1.0)
+            scores[context_id] = score
+
+        # Normalize scores so they sum to 1.0 (or close to it)
+        total = sum(scores.values())
+        if total > 0:
+            scores = {k: v / total for k, v in scores.items()}
+
+        return scores
+
+    def _llm_classify(self, message: str,
+                     recent_context: str = None) -> Dict[str, float]:
+        """Use LLM for nuanced classification.
+
+        Args:
+            message: The message to classify
+            recent_context: Recent conversation context
+
+        Returns:
+            Dict mapping context IDs to confidence scores
+        """
+        context_descriptions = "\n".join([
+            f"- {context_id}: {config['description']}"
+            for context_id, config in self.CONTEXT_TYPES.items()
+        ])
+
+        prompt = f"""Analyze this message and determine which conversation context it belongs to.
+
+AVAILABLE CONTEXTS:
+{context_descriptions}
+
+MESSAGE TO CLASSIFY:
+"{message}"
+
+{f'RECENT CONVERSATION CONTEXT:{chr(10)}{recent_context}' if recent_context else ''}
+
+Respond with ONLY a JSON object containing confidence scores (0.0 to 1.0) for each context.
+The scores should reflect how well the message fits each context.
+Example format:
+{{"work": 0.2, "personal": 0.1, "creative": 0.6, "reflection": 0.1}}
+
+Your response (JSON only):"""
+
+        try:
+            response = self.ollama_client.generate(
+                prompt=prompt,
+                system_prompt="You are a context classification assistant. Analyze messages and provide confidence scores as JSON. Be precise and consider the nuances of the message.",
+                temperature=0.3  # Lower temperature for more consistent classification
+            )
+
+            # Extract JSON from response
+            json_match = re.search(r'\{[^}]+\}', response)
+            if json_match:
+                scores = json.loads(json_match.group())
+                # Ensure all contexts are present
+                for context_id in self.CONTEXT_TYPES:
+                    if context_id not in scores:
+                        scores[context_id] = 0.0
+                return scores
+            else:
+                logger.warning(f"Could not parse LLM classification response: {response}")
+                return {context_id: 0.25 for context_id in self.CONTEXT_TYPES}
+
+        except Exception as e:
+            logger.error(f"LLM classification error: {e}")
+            raise
+
+    def should_switch_context(self, current_context_id: Optional[str],
+                             scores: Dict[str, float]) -> ContextSwitchResult:
+        """Determine if a context switch should occur.
+
+        Args:
+            current_context_id: ID of the current context (or None if no context)
+            scores: Confidence scores from classify_message()
+
+        Returns:
+            ContextSwitchResult with recommendation
+        """
+        if not scores:
+            return ContextSwitchResult(
+                should_switch=False,
+                recommended_context=None,
+                confidence=0.0,
+                needs_confirmation=False,
+                scores={}
+            )
+
+        # Find the highest-scoring context
+        best_context = max(scores, key=scores.get)
+        best_score = scores[best_context]
+
+        # If already in the best context, no switch needed
+        if current_context_id == best_context:
+            return ContextSwitchResult(
+                should_switch=False,
+                recommended_context=current_context_id,
+                confidence=best_score,
+                needs_confirmation=False,
+                scores=scores
+            )
+
+        # Determine if we should switch
+        if best_score >= self.auto_switch_threshold:
+            # High confidence - auto-switch
+            return ContextSwitchResult(
+                should_switch=True,
+                recommended_context=best_context,
+                confidence=best_score,
+                needs_confirmation=False,
+                scores=scores
+            )
+        elif best_score >= self.prompt_threshold:
+            # Medium confidence - ask user
+            return ContextSwitchResult(
+                should_switch=True,
+                recommended_context=best_context,
+                confidence=best_score,
+                needs_confirmation=True,
+                scores=scores
+            )
+        else:
+            # Low confidence - don't switch
+            return ContextSwitchResult(
+                should_switch=False,
+                recommended_context=None,
+                confidence=best_score,
+                needs_confirmation=False,
+                scores=scores
+            )
+
+    def detect_and_recommend(self, message: str,
+                            current_context_id: Optional[str] = None,
+                            recent_context: str = None) -> ContextSwitchResult:
+        """Convenience method to classify and get switch recommendation in one call.
+
+        Args:
+            message: The user message to analyze
+            current_context_id: ID of the current context
+            recent_context: Recent conversation context
+
+        Returns:
+            ContextSwitchResult with classification and recommendation
+        """
+        scores = self.classify_message(message, recent_context)
+        return self.should_switch_context(current_context_id, scores)
+
+    def get_context_description(self, context_id: str) -> str:
+        """Get the description for a context type.
+
+        Args:
+            context_id: The context ID
+
+        Returns:
+            Description string or empty string if not found
+        """
+        if context_id in self.CONTEXT_TYPES:
+            return self.CONTEXT_TYPES[context_id]["description"]
+        return ""

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from src.document_ingestion import DocumentIngestionTool
 from src.memory_system import MemorySystem, MemoryType
 from src.quotes_system import QuotesSystem
 from src.feedback_system import FeedbackManager, FeedbackType
+from src.context_detector import ContextDetector
 
 # Configure logging
 logging.basicConfig(
@@ -39,6 +40,16 @@ class GlennBot:
         self.orchestrator = AgentOrchestrator(self.knowledge_base, self.ollama_client, self.quotes_system)
         self.ingestion_tool = DocumentIngestionTool(self.knowledge_base, self.ollama_client)
         self.feedback_manager = FeedbackManager()
+
+        # Context detection with thresholds from memory system settings
+        self.context_detector = ContextDetector(
+            self.ollama_client,
+            auto_switch_threshold=self.memory_system.auto_switch_threshold,
+            prompt_threshold=self.memory_system.prompt_threshold
+        )
+
+        # Track pending context switch (awaiting user confirmation)
+        self.pending_context_switch = None
         
     def initialize(self):
         """Initialize the bot and load knowledge base."""
@@ -230,6 +241,20 @@ class GlennBot:
             filename = command.split(" ", 1)[1]
             self._import_knowledge(filename)
 
+        # Auto-context commands
+        elif command == "/auto-context":
+            self._show_auto_context_status()
+
+        elif command == "/auto-context on":
+            self._set_auto_context(True)
+
+        elif command == "/auto-context off":
+            self._set_auto_context(False)
+
+        elif command.startswith("/auto-context threshold "):
+            value_str = command[24:].strip()
+            self._set_auto_context_threshold(value_str)
+
         else:
             self.ui.display_error(f"Unknown command: {command}")
             
@@ -237,12 +262,34 @@ class GlennBot:
         
     def process_query(self, query: str):
         """Process a user query through the agent system."""
+        # Handle pending context switch confirmation
+        if self.pending_context_switch:
+            if query.lower() in ['y', 'yes']:
+                self._apply_context_switch(self.pending_context_switch)
+                self.pending_context_switch = None
+                return
+            elif query.lower() in ['n', 'no']:
+                self.ui.console.print("[yellow]Context switch cancelled[/yellow]")
+                self.pending_context_switch = None
+                return
+            else:
+                # Clear pending switch and process as normal query
+                self.pending_context_switch = None
+
+        # Auto-detect context if enabled
+        if self.memory_system.auto_switch_enabled:
+            self._detect_and_handle_context_switch(query)
+
+        # If there's a pending switch that needs confirmation, don't process query yet
+        if self.pending_context_switch:
+            return
+
         # Add to conversation
         self.conversation.add_message("user", query)
-        
+
         # Get memory context
         memory_context = self.memory_system.get_context_for_query(query)
-        
+
         # Prepare full context
         context = {
             "conversation_context": self.conversation.get_conversation_context(),
@@ -250,14 +297,14 @@ class GlennBot:
             "current_context": memory_context["current_context"],
             "relevant_memories": memory_context["relevant_memories"]
         }
-        
+
         try:
             with self.ui.show_thinking_indicator():
                 response = self.orchestrator.process_query(query, context)
-                
+
             self.conversation.add_message("assistant", response)
             self.ui.display_response(response)
-            
+
             # Extract and save important memories from this interaction
             recent_conversation = self.conversation.get_conversation_context(max_messages=4)
             if len(recent_conversation.split('\n')) > 6:  # Only if substantial conversation
@@ -268,7 +315,84 @@ class GlennBot:
         except Exception as e:
             logger.error(f"Error processing query: {e}")
             self.ui.display_error(f"Failed to process query: {e}")
-            
+
+    def _detect_and_handle_context_switch(self, query: str):
+        """Detect context from query and handle switching."""
+        try:
+            current_context_id = (
+                self.memory_system.current_context.id
+                if self.memory_system.current_context
+                else None
+            )
+
+            # Get recent conversation context for better classification
+            recent_context = self.conversation.get_conversation_context(max_messages=3)
+
+            # Detect context
+            result = self.context_detector.detect_and_recommend(
+                query,
+                current_context_id=current_context_id,
+                recent_context=recent_context
+            )
+
+            if result.should_switch and result.recommended_context:
+                # Check if the recommended context exists in memory system
+                if result.recommended_context not in self.memory_system.contexts:
+                    # Context doesn't exist yet, skip switch
+                    return
+
+                if result.needs_confirmation:
+                    # Prompt user for confirmation
+                    context = self.memory_system.contexts[result.recommended_context]
+                    self.ui.console.print(
+                        f"[yellow]Detected topic shift to '{context.name}' "
+                        f"(confidence: {result.confidence:.0%})[/yellow]"
+                    )
+                    self.ui.console.print(
+                        f"[yellow]Switch context? (y/n)[/yellow]"
+                    )
+                    self.pending_context_switch = {
+                        "to_context": result.recommended_context,
+                        "from_context": current_context_id,
+                        "confidence": result.confidence
+                    }
+                else:
+                    # Auto-switch silently
+                    self._apply_context_switch({
+                        "to_context": result.recommended_context,
+                        "from_context": current_context_id,
+                        "confidence": result.confidence
+                    }, silent=True)
+
+        except Exception as e:
+            logger.warning(f"Context detection failed: {e}")
+            # Continue without context switching on failure
+
+    def _apply_context_switch(self, switch_info: dict, silent: bool = False):
+        """Apply a context switch."""
+        to_context = switch_info["to_context"]
+        from_context = switch_info.get("from_context")
+        confidence = switch_info.get("confidence", 1.0)
+
+        if self.memory_system.switch_context(to_context):
+            context = self.memory_system.current_context
+            if not silent:
+                self.ui.console.print(f"[green]Switched to: {context.name}[/green]")
+            else:
+                self.ui.console.print(
+                    f"[dim]Auto-switched to '{context.name}' context[/dim]"
+                )
+
+            # Record the switch for learning
+            self.memory_system.record_context_switch(
+                from_context=from_context or "none",
+                to_context=to_context,
+                was_auto=silent,
+                confidence=confidence
+            )
+        else:
+            self.ui.display_error(f"Failed to switch to context '{to_context}'")
+
     def _handle_url_ingestion(self, url: str, context: str):
         """Handle adding content from a URL."""
         try:
@@ -341,7 +465,59 @@ class GlennBot:
             )
             
         self.ui.console.print(table)
-        
+
+    def _show_auto_context_status(self):
+        """Show current auto-context settings."""
+        enabled = self.memory_system.auto_switch_enabled
+        auto_threshold = self.memory_system.auto_switch_threshold
+        prompt_threshold = self.memory_system.prompt_threshold
+
+        from rich.panel import Panel
+        from rich.text import Text
+
+        status_text = Text()
+        status_text.append("Auto-context: ", style="bold")
+        status_text.append(
+            "Enabled" if enabled else "Disabled",
+            style="green" if enabled else "red"
+        )
+        status_text.append("\n\n")
+        status_text.append("Auto-switch threshold: ", style="bold")
+        status_text.append(f"{auto_threshold:.0%}", style="cyan")
+        status_text.append(" (switches silently above this)\n")
+        status_text.append("Prompt threshold: ", style="bold")
+        status_text.append(f"{prompt_threshold:.0%}", style="cyan")
+        status_text.append(" (asks for confirmation above this)\n\n")
+        status_text.append("Commands:\n", style="bold")
+        status_text.append("  /auto-context on       - Enable auto-switching\n", style="dim")
+        status_text.append("  /auto-context off      - Disable auto-switching\n", style="dim")
+        status_text.append("  /auto-context threshold <value>  - Set auto-switch threshold (0.0-1.0)\n", style="dim")
+
+        panel = Panel(status_text, title="Auto-Context Settings", border_style="blue")
+        self.ui.console.print(panel)
+
+    def _set_auto_context(self, enabled: bool):
+        """Enable or disable auto-context switching."""
+        self.memory_system.auto_switch_enabled = enabled
+        status = "enabled" if enabled else "disabled"
+        self.ui.console.print(f"[green]Auto-context switching {status}[/green]")
+
+    def _set_auto_context_threshold(self, value_str: str):
+        """Set the auto-context switching threshold."""
+        try:
+            value = float(value_str)
+            if value < 0.0 or value > 1.0:
+                self.ui.display_error("Threshold must be between 0.0 and 1.0")
+                return
+
+            self.memory_system.auto_switch_threshold = value
+            # Update the context detector's threshold too
+            self.context_detector.auto_switch_threshold = value
+            self.ui.console.print(f"[green]Auto-switch threshold set to {value:.0%}[/green]")
+
+        except ValueError:
+            self.ui.display_error(f"Invalid threshold value: {value_str}")
+
     def _switch_context(self, context_id: str):
         """Switch to a different context."""
         if self.memory_system.switch_context(context_id):

--- a/src/memory_system.py
+++ b/src/memory_system.py
@@ -83,23 +83,30 @@ class Context:
 
 class MemorySystem:
     """Manages persistent memory and context switching."""
-    
+
     def __init__(self, knowledge_base: KnowledgeBase, ollama_client: OllamaClient):
         self.knowledge_base = knowledge_base
         self.ollama_client = ollama_client
         self.memory_dir = settings.conversation_history_dir.parent / "memory"
         self.contexts_dir = self.memory_dir / "contexts"
         self.memories_file = self.memory_dir / "memories.json"
-        
+        self.settings_file = self.memory_dir / "settings.json"
+
         # Create directories
         self.memory_dir.mkdir(parents=True, exist_ok=True)
         self.contexts_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # Load existing data
         self.memories: Dict[str, Memory] = self._load_memories()
         self.contexts: Dict[str, Context] = self._load_contexts()
         self.current_context: Optional[Context] = None
-        
+
+        # Auto-switch settings
+        self._auto_switch_settings = self._load_auto_switch_settings()
+
+        # Context switch history for learning
+        self.context_switch_history: List[Dict[str, Any]] = []
+
         # Initialize with basic contexts if none exist
         if not self.contexts:
             self._create_default_contexts()
@@ -128,7 +135,88 @@ class MemorySystem:
                 json.dump(data, f, indent=2)
         except Exception as e:
             logger.error(f"Error saving memories: {e}")
-            
+
+    def _load_auto_switch_settings(self) -> Dict[str, Any]:
+        """Load auto-switch settings from storage."""
+        default_settings = {
+            "enabled": True,
+            "auto_switch_threshold": 0.8,
+            "prompt_threshold": 0.6,
+            "switch_history": []
+        }
+
+        if not self.settings_file.exists():
+            return default_settings
+
+        try:
+            with open(self.settings_file, 'r') as f:
+                data = json.load(f)
+                # Merge with defaults to ensure all keys exist
+                return {**default_settings, **data}
+        except Exception as e:
+            logger.error(f"Error loading auto-switch settings: {e}")
+            return default_settings
+
+    def _save_auto_switch_settings(self):
+        """Save auto-switch settings to storage."""
+        try:
+            with open(self.settings_file, 'w') as f:
+                json.dump(self._auto_switch_settings, f, indent=2)
+        except Exception as e:
+            logger.error(f"Error saving auto-switch settings: {e}")
+
+    @property
+    def auto_switch_enabled(self) -> bool:
+        """Check if auto-switching is enabled."""
+        return self._auto_switch_settings.get("enabled", True)
+
+    @auto_switch_enabled.setter
+    def auto_switch_enabled(self, value: bool):
+        """Enable or disable auto-switching."""
+        self._auto_switch_settings["enabled"] = value
+        self._save_auto_switch_settings()
+
+    @property
+    def auto_switch_threshold(self) -> float:
+        """Get the auto-switch threshold."""
+        return self._auto_switch_settings.get("auto_switch_threshold", 0.8)
+
+    @auto_switch_threshold.setter
+    def auto_switch_threshold(self, value: float):
+        """Set the auto-switch threshold."""
+        self._auto_switch_settings["auto_switch_threshold"] = max(0.0, min(1.0, value))
+        self._save_auto_switch_settings()
+
+    @property
+    def prompt_threshold(self) -> float:
+        """Get the prompt threshold."""
+        return self._auto_switch_settings.get("prompt_threshold", 0.6)
+
+    @prompt_threshold.setter
+    def prompt_threshold(self, value: float):
+        """Set the prompt threshold."""
+        self._auto_switch_settings["prompt_threshold"] = max(0.0, min(1.0, value))
+        self._save_auto_switch_settings()
+
+    def record_context_switch(self, from_context: str, to_context: str,
+                             was_auto: bool, confidence: float):
+        """Record a context switch for learning purposes."""
+        switch_record = {
+            "from": from_context,
+            "to": to_context,
+            "was_auto": was_auto,
+            "confidence": confidence,
+            "timestamp": datetime.now().isoformat()
+        }
+        self.context_switch_history.append(switch_record)
+
+        # Keep in settings for persistence
+        history = self._auto_switch_settings.get("switch_history", [])
+        history.append(switch_record)
+        # Keep only last 100 switches
+        self._auto_switch_settings["switch_history"] = history[-100:]
+        self._save_auto_switch_settings()
+
     def _load_contexts(self) -> Dict[str, Context]:
         """Load contexts from storage."""
         contexts = {}
@@ -156,6 +244,44 @@ class MemorySystem:
     def _create_default_contexts(self):
         """Create default operating contexts."""
         default_contexts = [
+            # Core auto-detected contexts (work, personal, creative, reflection)
+            {
+                "id": "work",
+                "name": "Work",
+                "description": "Professional work, career, business tasks, meetings, deadlines",
+                "context_type": "work",
+                "goals": ["Complete projects", "Meet deadlines", "Professional growth"],
+                "key_people": [],
+                "current_focus": "Current tasks"
+            },
+            {
+                "id": "personal",
+                "name": "Personal",
+                "description": "Personal life, family, friends, health, daily activities",
+                "context_type": "personal",
+                "goals": ["Work-life balance", "Healthy relationships", "Personal wellbeing"],
+                "key_people": [],
+                "current_focus": "Daily life"
+            },
+            {
+                "id": "creative",
+                "name": "Creative",
+                "description": "Creative projects, art, writing, music, brainstorming ideas",
+                "context_type": "creative",
+                "goals": ["Express creativity", "Complete creative projects", "Explore ideas"],
+                "key_people": [],
+                "current_focus": "Creative exploration"
+            },
+            {
+                "id": "reflection",
+                "name": "Reflection",
+                "description": "Self-reflection, personal growth, philosophy, deep thinking",
+                "context_type": "reflection",
+                "goals": ["Self-awareness", "Personal growth", "Deeper understanding"],
+                "key_people": [],
+                "current_focus": "Self-discovery"
+            },
+            # Additional specialized contexts
             {
                 "id": "personal_brand",
                 "name": "Personal Brand Building",
@@ -169,7 +295,7 @@ class MemorySystem:
                 "id": "product_dev",
                 "name": "Product Development",
                 "description": "Working on product ideas, development, and improvement",
-                "context_type": "product_development", 
+                "context_type": "product_development",
                 "goals": ["Build innovative products", "Solve user problems", "Generate value"],
                 "key_people": [],
                 "current_focus": "Ideation phase"

--- a/tests/test_context_detector.py
+++ b/tests/test_context_detector.py
@@ -1,0 +1,232 @@
+"""Tests for context_detector.py - Context auto-detection and switching."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestContextDetector:
+    """Test cases for ContextDetector class."""
+
+    @pytest.fixture
+    def context_detector(self, mock_ollama_client):
+        """Create a ContextDetector instance for testing."""
+        from src.context_detector import ContextDetector
+        return ContextDetector(
+            ollama_client=mock_ollama_client,
+            auto_switch_threshold=0.8,
+            prompt_threshold=0.6
+        )
+
+    def test_init_with_defaults(self, mock_ollama_client):
+        """Test ContextDetector initialization with default values."""
+        from src.context_detector import ContextDetector
+        detector = ContextDetector(mock_ollama_client)
+
+        assert detector.auto_switch_threshold == 0.8
+        assert detector.prompt_threshold == 0.6
+        assert detector.ollama_client == mock_ollama_client
+
+    def test_init_with_custom_thresholds(self, mock_ollama_client):
+        """Test ContextDetector initialization with custom thresholds."""
+        from src.context_detector import ContextDetector
+        detector = ContextDetector(
+            mock_ollama_client,
+            auto_switch_threshold=0.9,
+            prompt_threshold=0.7
+        )
+
+        assert detector.auto_switch_threshold == 0.9
+        assert detector.prompt_threshold == 0.7
+
+    def test_keyword_classify_work_context(self, context_detector):
+        """Test keyword classification for work-related messages."""
+        message = "I need to finish the project report before the deadline"
+        scores = context_detector._keyword_classify(message)
+
+        assert "work" in scores
+        assert "personal" in scores
+        assert "creative" in scores
+        assert "reflection" in scores
+        # Work should have highest or significant score
+        assert scores["work"] > 0
+
+    def test_keyword_classify_personal_context(self, context_detector):
+        """Test keyword classification for personal messages."""
+        message = "Planning a family dinner for my friend's birthday"
+        scores = context_detector._keyword_classify(message)
+
+        assert scores["personal"] > 0
+
+    def test_keyword_classify_creative_context(self, context_detector):
+        """Test keyword classification for creative messages."""
+        message = "I want to write a story and brainstorm some ideas"
+        scores = context_detector._keyword_classify(message)
+
+        assert scores["creative"] > 0
+
+    def test_keyword_classify_reflection_context(self, context_detector):
+        """Test keyword classification for reflection messages."""
+        message = "I need to reflect on my goals and think about my purpose"
+        scores = context_detector._keyword_classify(message)
+
+        assert scores["reflection"] > 0
+
+    def test_keyword_classify_scores_normalized(self, context_detector):
+        """Test that keyword classification scores are normalized."""
+        message = "project deadline meeting report"
+        scores = context_detector._keyword_classify(message)
+
+        # Scores should sum to approximately 1.0
+        total = sum(scores.values())
+        assert 0.99 <= total <= 1.01
+
+    def test_keyword_classify_empty_message(self, context_detector):
+        """Test keyword classification with empty message."""
+        message = ""
+        scores = context_detector._keyword_classify(message)
+
+        # All scores should be 0 for empty message
+        assert all(score == 0 for score in scores.values())
+
+    def test_should_switch_context_auto_switch(self, context_detector):
+        """Test should_switch_context with high confidence (auto-switch)."""
+        scores = {"work": 0.85, "personal": 0.05, "creative": 0.05, "reflection": 0.05}
+        result = context_detector.should_switch_context("personal", scores)
+
+        assert result.should_switch is True
+        assert result.recommended_context == "work"
+        assert result.needs_confirmation is False
+        assert result.confidence == 0.85
+
+    def test_should_switch_context_needs_confirmation(self, context_detector):
+        """Test should_switch_context with medium confidence (needs confirmation)."""
+        scores = {"work": 0.7, "personal": 0.1, "creative": 0.1, "reflection": 0.1}
+        result = context_detector.should_switch_context("personal", scores)
+
+        assert result.should_switch is True
+        assert result.recommended_context == "work"
+        assert result.needs_confirmation is True
+        assert result.confidence == 0.7
+
+    def test_should_switch_context_low_confidence(self, context_detector):
+        """Test should_switch_context with low confidence (no switch)."""
+        scores = {"work": 0.4, "personal": 0.3, "creative": 0.2, "reflection": 0.1}
+        result = context_detector.should_switch_context("personal", scores)
+
+        assert result.should_switch is False
+        assert result.recommended_context is None
+        assert result.needs_confirmation is False
+
+    def test_should_switch_context_already_in_best_context(self, context_detector):
+        """Test should_switch_context when already in the best context."""
+        scores = {"work": 0.9, "personal": 0.05, "creative": 0.03, "reflection": 0.02}
+        result = context_detector.should_switch_context("work", scores)
+
+        assert result.should_switch is False
+        assert result.recommended_context == "work"
+
+    def test_should_switch_context_empty_scores(self, context_detector):
+        """Test should_switch_context with empty scores."""
+        result = context_detector.should_switch_context("personal", {})
+
+        assert result.should_switch is False
+        assert result.recommended_context is None
+
+    def test_should_switch_context_no_current_context(self, context_detector):
+        """Test should_switch_context with no current context."""
+        scores = {"work": 0.85, "personal": 0.05, "creative": 0.05, "reflection": 0.05}
+        result = context_detector.should_switch_context(None, scores)
+
+        assert result.should_switch is True
+        assert result.recommended_context == "work"
+
+    def test_llm_classify_success(self, context_detector, mock_ollama_client):
+        """Test LLM classification with successful response."""
+        mock_ollama_client.generate.return_value = '{"work": 0.8, "personal": 0.1, "creative": 0.05, "reflection": 0.05}'
+
+        scores = context_detector._llm_classify("I need to prepare for tomorrow's meeting")
+
+        assert scores["work"] == 0.8
+        assert scores["personal"] == 0.1
+        mock_ollama_client.generate.assert_called_once()
+
+    def test_llm_classify_missing_contexts_filled(self, context_detector, mock_ollama_client):
+        """Test LLM classification fills in missing context scores."""
+        mock_ollama_client.generate.return_value = '{"work": 0.9}'
+
+        scores = context_detector._llm_classify("Work task")
+
+        assert scores["work"] == 0.9
+        assert scores["personal"] == 0.0
+        assert scores["creative"] == 0.0
+        assert scores["reflection"] == 0.0
+
+    def test_llm_classify_invalid_json(self, context_detector, mock_ollama_client):
+        """Test LLM classification with invalid JSON response."""
+        mock_ollama_client.generate.return_value = "This is not valid JSON"
+
+        scores = context_detector._llm_classify("Some message")
+
+        # Should return equal scores for all contexts as fallback
+        assert all(score == 0.25 for score in scores.values())
+
+    def test_classify_message_uses_keywords_for_high_confidence(self, context_detector):
+        """Test classify_message uses keywords when confidence is high."""
+        # Multiple work keywords should give high keyword confidence
+        message = "project deadline meeting report task"
+        scores = context_detector.classify_message(message)
+
+        assert "work" in scores
+        assert scores["work"] > 0
+
+    def test_classify_message_uses_llm_for_low_keyword_confidence(self, context_detector, mock_ollama_client):
+        """Test classify_message uses LLM when keyword confidence is low."""
+        mock_ollama_client.generate.return_value = '{"work": 0.2, "personal": 0.6, "creative": 0.1, "reflection": 0.1}'
+
+        # Message without clear keywords
+        message = "Let's plan something nice for the evening"
+        scores = context_detector.classify_message(message)
+
+        # Should blend keyword and LLM scores
+        assert "personal" in scores
+
+    def test_detect_and_recommend_convenience_method(self, context_detector):
+        """Test detect_and_recommend convenience method."""
+        result = context_detector.detect_and_recommend(
+            message="project deadline tomorrow",
+            current_context_id="personal"
+        )
+
+        assert hasattr(result, 'should_switch')
+        assert hasattr(result, 'recommended_context')
+        assert hasattr(result, 'confidence')
+        assert hasattr(result, 'needs_confirmation')
+        assert hasattr(result, 'scores')
+
+    def test_get_context_description(self, context_detector):
+        """Test getting context descriptions."""
+        assert "work" in context_detector.get_context_description("work").lower() or \
+               "professional" in context_detector.get_context_description("work").lower()
+        assert context_detector.get_context_description("nonexistent") == ""
+
+
+class TestContextSwitchResult:
+    """Test cases for ContextSwitchResult dataclass."""
+
+    def test_context_switch_result_creation(self):
+        """Test creating a ContextSwitchResult."""
+        from src.context_detector import ContextSwitchResult
+
+        result = ContextSwitchResult(
+            should_switch=True,
+            recommended_context="work",
+            confidence=0.85,
+            needs_confirmation=False,
+            scores={"work": 0.85, "personal": 0.15}
+        )
+
+        assert result.should_switch is True
+        assert result.recommended_context == "work"
+        assert result.confidence == 0.85
+        assert result.needs_confirmation is False
+        assert result.scores == {"work": 0.85, "personal": 0.15}


### PR DESCRIPTION
## Summary

- Adds automatic context detection based on conversation topics
- System can detect work, personal, creative, and reflection contexts
- Configurable confidence thresholds for auto-switch vs user confirmation
- New `/auto-context` command for user control

## Implementation Details

### New Components
- **ContextDetector** (`src/context_detector.py`): Analyzes messages using keyword matching and LLM-based classification
- **Auto-switch settings**: Persisted settings in MemorySystem with configurable thresholds

### Context Detection Flow
1. User sends a message
2. If auto-switch is enabled, ContextDetector classifies the message
3. Based on confidence level:
   - **>0.8**: Auto-switches silently
   - **0.6-0.8**: Prompts user for confirmation
   - **<0.6**: Keeps current context

### New Commands
- `/auto-context` - Show current settings
- `/auto-context on` - Enable auto-switching
- `/auto-context off` - Disable auto-switching
- `/auto-context threshold <value>` - Set confidence threshold

## Test plan
- [x] Syntax check passes
- [x] Unit tests created for ContextDetector
- [ ] Manual testing of context detection with various message types
- [ ] Verify auto-switch and confirmation prompts work correctly

Closes #12

---
Generated with [Claude Code](https://claude.com/claude-code)